### PR TITLE
docs(personas): Align README with actual persona structure

### DIFF
--- a/personas/README.md
+++ b/personas/README.md
@@ -4,19 +4,25 @@ This directory contains the personas we use for human-agent collaboration. Each 
 
 ## Structure of a Persona
 
-Every persona has two sections:
+Every persona has three sections:
 
 ### Role
 Who you are and how you work.
-- **Purpose**: What this role does and why it exists.
+- **Opening paragraph**: What this role does and why it exists.
 - **Tone**: The voice and style for this role.
-- **Workflow**: How to approach and complete work.
-- **Success**: What good work looks like.
+
+### Workflow
+How to approach and complete work.
+- **Numbered steps**: The sequence of actions to follow.
+- **Success**: What good work looks like—appears at the end of this section.
 
 ### Guardrails
 Where your authority ends and what to protect.
-- **When to Stop**: Moments to pause and consult rather than guess.
-- **Integrity Rules**: What to protect, avoid, or never do.
+- **When to pause**: Moments to stop and consult rather than guess.
+- **Integrity rules**: What to protect, avoid, or never do.
+- **Prohibited Actions**: Explicit actions that require escalation to a human.
+
+All personas should reference the [Foundational Principles](../PRINCIPLES.md) and [Contribution Guidelines](../CONTRIBUTING.md) where appropriate.
 
 ---
 
@@ -26,9 +32,12 @@ Use this prompt to draft a new persona:
 
 > "Draft a persona for the role: **[ROLE NAME]**.
 > 
-> Structure it with two sections:
-> 1. **Role** — purpose, tone, workflow, and what success looks like.
-> 2. **Guardrails** — when to stop and consult, and integrity rules.
+> Structure it with three sections:
+> 1. **Role** — an opening paragraph stating the purpose, followed by the tone.
+> 2. **Workflow** — numbered steps for how to work, ending with what success looks like.
+> 3. **Guardrails** — when to pause and consult, integrity rules, and prohibited actions that require escalation.
+> 
+> Reference the project's [Foundational Principles](../PRINCIPLES.md) and [Contribution Guidelines](../CONTRIBUTING.md) where appropriate.
 > 
 > Keep the language professional, human-centered, and direct."
 


### PR DESCRIPTION
## Summary

Aligns the personas/README.md guidelines with how existing personas are actually structured.

## Problem

The README template drifted from the structure used in existing personas (Contributor, Leader, Prompter, Reviewer, Scribe). This created inconsistency for anyone creating new personas or onboarding to the project.

## Changes

- **Structure**: Split into three sections (Role, Workflow, Guardrails) to match actual personas
- **Prohibited Actions**: Added missing subsection that all personas include
- **Creation prompt**: Updated to include project reference guidance (PRINCIPLES.md, CONTRIBUTING.md)
- **Wording**: Corrected 'When to Stop' to 'When to pause' per actual usage

## Verification

Compared the updated README template against all five existing personas to confirm alignment.

Closes #11