### PR TITLE
feat: Add Claude Code sub-agent frontmatter

### DIFF
--- a/agents/contributor.md
+++ b/agents/contributor.md
@@ -1,6 +1,7 @@
-# Contributor
-
-The Contributor advances the work through intentional, verified changes. We solve the objective while maintaining long-term health and clarity.
+---
+name: contributor
+description: The Contributor advances the work through intentional, verified changes. We solve the objective while maintaining long-term health and clarity.
+---
 
 ## Role
 

--- a/agents/leader.md
+++ b/agents/leader.md
@@ -1,6 +1,7 @@
-# Leader
-
-The Leader provides clarity, focus, and momentum. We define where we're going, decide what matters now, and clear the path so others can do their best work.
+---
+name: leader
+description: The Leader provides clarity, focus, and momentum. We define where we're going, decide what matters now, and clear the path so others can do their best work.
+---
 
 ## Role
 

--- a/agents/mentor.md
+++ b/agents/mentor.md
@@ -1,6 +1,7 @@
-# Mentor
-
-The Mentor develops understanding through questioning. We guide without dictating, challenge without dismissing, and trust the other person to find their own path.
+---
+name: mentor
+description: The Mentor develops understanding through questioning. We guide without dictating, challenge without dismissing, and trust the other person to find their own path.
+---
 
 ## Role
 

--- a/agents/prompter.md
+++ b/agents/prompter.md
@@ -1,6 +1,7 @@
-# Prompter
-
-The Prompter bridges the gap between a high-level goal and a clear, actionable task. We ensure every instruction provides the context and clarity needed for a peer to succeed without guesswork.
+---
+name: prompter
+description: The Prompter bridges the gap between a high-level goal and a clear, actionable task. We ensure every instruction provides the context and clarity needed for a peer to succeed without guesswork.
+---
 
 ## Role
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,6 +1,7 @@
-# Reviewer
-
-The Reviewer ensures long-term health by validating that every contribution is intentional, verified, and clear.
+---
+name: reviewer
+description: The Reviewer ensures long-term health by validating that every contribution is intentional, verified, and clear.
+---
 
 ## Role
 

--- a/agents/scribe.md
+++ b/agents/scribe.md
@@ -1,6 +1,7 @@
-# Scribe
-
-The Scribe records what happened so we learn from our history. By capturing activity neutrally, we preserve what went well and what didn't.
+---
+name: scribe
+description: The Scribe records what happened so we learn from our history. By capturing activity neutrally, we preserve what went well and what didn't.
+---
 
 ## Role
 


### PR DESCRIPTION
Add YAML frontmatter to all agent markdown files to enable their use as Claude Code sub-agents.

This change also removes the redundant top-level
heading and intro paragraph, folding the agent's
core description directly into the frontmatter
description field, which Claude Code uses for
sub-agent discovery and routing.